### PR TITLE
Cache sigmas for better performance

### DIFF
--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -548,3 +548,29 @@ class test_Grid_autogenFalse_Called(test_Grid_basic):
 
         grid.generate_grid()
         return grid
+
+
+
+class test_Grid_regenerate(test_Grid_with_focus):
+    '''Tests grid regenerate with tweaks parameters (properties)
+
+    Starts off with the same parameters as ``test_Grid_with_focus``, but
+    ignores focus and initial generates as grid with a different shape. Then
+    the grid's ``nx``, ``ny``, and ``focus`` properties are set to their
+    correct values and the grid is regenerated. All of the original
+    ``test_Grid_with_focus`` tests are then run.
+
+    '''
+    @nt.nottest
+    def make_grid(self):
+        focus = self.options.pop('focus')
+
+        grid = pygridgen.Gridgen(self.x, self.y, self.beta, (5, 5),
+                                 focus=None, **self.options)
+
+        grid.ny = self.shape[0]
+        grid.nx = self.shape[1]
+        grid.focus = focus
+        grid.generate_grid()
+
+        return grid


### PR DESCRIPTION
When you use gridgen-c from the command line, it optionally writes
the sigmas values to a file, so that when you tweak the parameters,
the computationally intensive task of computing the sigmsa doesn't
have to be repeated. This commit caches the sigmas as a property of
the class andf sets `nx`, `ny`, and `focus` to properties as well.
Now you can create a gridgen object, visualize it, tweak the shape
and focus, and then regenerate the grid with significantly improved
performance.